### PR TITLE
Fix missing lib directory in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update -y && \
       texlive-latex-extra=2018.20190227-2 \
       texlive-bibtex-extra=2018.20190227-2
 ADD ./bin /gen-pdf/bin
+ADD ./lib /gen-pdf/lib
 ADD ./resources /gen-pdf/resources
 ENV PATH /gen-pdf/bin:$PATH
 CMD ["bash"]


### PR DESCRIPTION
Otherwise building PDF using Docker does not work with:

```
Traceback (most recent call last):
        2: from /gen-pdf/bin/gen-pdf:21:in `<main>'
        1: from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
/usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require': cannot load such file -- bhxiv/markdown (LoadError)
```

(Please change base branch to other if needed, `dev` seems to be an unused branch.)